### PR TITLE
Add simple Flask dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# ai-bot
+# Crypto Analysis Dashboard
+
+This repository contains a simple Flask application that shows coin data with confidence scores and allows running backtests.
+
+## Requirements
+- Python 3.12
+- Flask
+
+Install dependencies:
+```bash
+pip3 install flask
+```
+
+## Running
+```bash
+python3 app.py
+```
+
+Then open `http://localhost:5000` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,45 @@
+import random
+from flask import Flask, render_template, jsonify, request
+
+app = Flask(__name__)
+
+# Example coin data
+coins = [
+    {"name": "Bitcoin", "confidence": 0.8},
+    {"name": "Ethereum", "confidence": 0.75},
+    {"name": "Litecoin", "confidence": 0.6},
+]
+
+# Indicator info per coin
+indicators = {
+    c["name"]: {"rsi": random.randint(20, 80), "reversal": False} for c in coins
+}
+
+def refresh_data():
+    """Update coin scores and indicators with random values."""
+    for coin in coins:
+        coin["confidence"] = round(random.random(), 2)
+        indicators[coin["name"]] = {
+            "rsi": random.randint(20, 80),
+            "reversal": random.random() > 0.8,
+        }
+
+@app.route("/")
+def index():
+    refresh_data()
+    return render_template("index.html", coins=coins, indicators=indicators)
+
+@app.route("/update")
+def update():
+    refresh_data()
+    return jsonify({"coins": coins, "indicators": indicators})
+
+@app.route("/backtest", methods=["POST"])
+def backtest():
+    coin = request.json.get("coin")
+    # Placeholder for running backtests
+    message = f"Backtest triggered for {coin}"
+    return jsonify({"message": message})
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Crypto Dashboard</title>
+</head>
+<body>
+<h1>Top Coins</h1>
+<table id="coin-table" border="1">
+  <thead>
+    <tr><th>Coin</th><th>Confidence</th><th>RSI</th><th>Reversal?</th><th>Backtest</th></tr>
+  </thead>
+  <tbody>
+    {% for coin in coins %}
+    <tr data-coin="{{ coin.name }}">
+      <td>{{ coin.name }}</td>
+      <td class="confidence">{{ coin.confidence }}</td>
+      <td class="rsi">{{ indicators[coin.name].rsi }}</td>
+      <td class="reversal">{{ indicators[coin.name].reversal }}</td>
+      <td><button class="backtest">Run</button></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<script>
+function refreshData() {
+  fetch('/update').then(r => r.json()).then(data => {
+    data.coins.forEach(c => {
+      const row = document.querySelector('tr[data-coin="' + c.name + '"]');
+      if(row){
+        row.querySelector('.confidence').textContent = c.confidence;
+        row.querySelector('.rsi').textContent = data.indicators[c.name].rsi;
+        row.querySelector('.reversal').textContent = data.indicators[c.name].reversal;
+      }
+    });
+  });
+}
+setInterval(refreshData, 5000);
+
+document.querySelectorAll('.backtest').forEach(btn => {
+  btn.addEventListener('click', function() {
+    const coin = this.closest('tr').dataset.coin;
+    fetch('/backtest', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({coin})
+    }).then(r => r.json()).then(res => alert(res.message));
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask app for coin analysis
- create basic dashboard template
- update README with instructions

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6870fe5a841c832a9f6ff951de944ba1