### PR TITLE
Add simple backtesting package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/backtesting/__init__.py
+++ b/backtesting/__init__.py
@@ -1,0 +1,14 @@
+"""Backtesting package for running historical simulations."""
+
+from .data import load_price_data
+from .indicators import moving_average, crossover_strategy
+from .backtester import run_backtest
+from . import metrics
+
+__all__ = [
+    'load_price_data',
+    'moving_average',
+    'crossover_strategy',
+    'run_backtest',
+    'metrics',
+]

--- a/backtesting/backtester.py
+++ b/backtesting/backtester.py
@@ -1,0 +1,38 @@
+import pandas as pd
+from .metrics import (
+    cumulative_returns,
+    annual_return,
+    annual_volatility,
+    sharpe_ratio,
+    max_drawdown,
+)
+
+
+def run_backtest(data: pd.DataFrame, strategy_fn, **strategy_kwargs) -> dict:
+    """Run a backtest using a strategy function.
+
+    Parameters
+    ----------
+    data : DataFrame
+        Price data with a 'Close' column.
+    strategy_fn : callable
+        Function that accepts ``data`` and returns a Series of signals (1 or 0).
+    strategy_kwargs : dict
+        Additional keyword arguments passed to ``strategy_fn``.
+    Returns
+    -------
+    dict
+        Performance metrics of the strategy.
+    """
+    signals = strategy_fn(data, **strategy_kwargs)
+    returns = data['Close'].pct_change().fillna(0)
+    strat_returns = signals.shift(1).fillna(0) * returns
+
+    metrics = {
+        'cumulative_return': cumulative_returns(strat_returns).iloc[-1],
+        'annual_return': annual_return(strat_returns),
+        'annual_volatility': annual_volatility(strat_returns),
+        'sharpe_ratio': sharpe_ratio(strat_returns),
+        'max_drawdown': max_drawdown(strat_returns),
+    }
+    return metrics

--- a/backtesting/data.py
+++ b/backtesting/data.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+
+def load_price_data(filepath: str) -> pd.DataFrame:
+    """Load OHLCV price data from a CSV file.
+
+    The CSV should contain columns like 'Open', 'High', 'Low', 'Close', 'Volume'.
+    The function parses dates and sets the index to the first column.
+    """
+    df = pd.read_csv(filepath, index_col=0, parse_dates=True)
+    return df

--- a/backtesting/indicators.py
+++ b/backtesting/indicators.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+
+def moving_average(series: pd.Series, window: int) -> pd.Series:
+    """Simple moving average."""
+    return series.rolling(window).mean()
+
+
+def crossover_strategy(df: pd.DataFrame, short_window: int = 50, long_window: int = 200) -> pd.Series:
+    """Generate trading signals based on moving average crossover.
+
+    Returns a Series of 1 (long) or 0 (flat) signals.
+    """
+    short_ma = moving_average(df['Close'], short_window)
+    long_ma = moving_average(df['Close'], long_window)
+    signals = (short_ma > long_ma).astype(int)
+    return signals

--- a/backtesting/metrics.py
+++ b/backtesting/metrics.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import numpy as np
+
+
+def cumulative_returns(returns: pd.Series) -> pd.Series:
+    """Compute cumulative returns from periodic returns."""
+    return (1 + returns).cumprod() - 1
+
+
+def annual_return(returns: pd.Series, periods_per_year: int = 252) -> float:
+    compounded = (1 + returns).prod()
+    years = len(returns) / periods_per_year
+    return compounded ** (1 / years) - 1 if years > 0 else np.nan
+
+
+def annual_volatility(returns: pd.Series, periods_per_year: int = 252) -> float:
+    return returns.std() * np.sqrt(periods_per_year)
+
+
+def sharpe_ratio(returns: pd.Series, risk_free_rate: float = 0.0, periods_per_year: int = 252) -> float:
+    excess = returns - risk_free_rate / periods_per_year
+    vol = returns.std()
+    return np.nan if vol == 0 else (excess.mean() / vol) * np.sqrt(periods_per_year)
+
+
+def max_drawdown(returns: pd.Series) -> float:
+    cum = cumulative_returns(returns) + 1
+    peak = cum.cummax()
+    drawdown = (cum - peak) / peak
+    return drawdown.min()

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import numpy as np
+
+from backtesting import crossover_strategy, run_backtest
+
+
+def create_sample_data(days=300):
+    rng = pd.date_range('2020-01-01', periods=days, freq='D')
+    prices = 100 + np.cumsum(np.random.randn(days))
+    df = pd.DataFrame({'Close': prices}, index=rng)
+    return df
+
+
+def test_backtest_runs():
+    data = create_sample_data()
+    metrics = run_backtest(data, crossover_strategy, short_window=5, long_window=20)
+    assert 'cumulative_return' in metrics
+    assert 'sharpe_ratio' in metrics


### PR DESCRIPTION
## Summary
- create basic backtesting package
- provide moving average indicator and crossover strategy
- implement performance metric helpers
- enable running historical strategy simulations
- add tests for the new backtesting tools
- ignore compiled artifacts

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870fe583404832a93655e305736bec3